### PR TITLE
Set LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON for standalone LLDB builds

### DIFF
--- a/lldb-multipython/CMakeLists.txt
+++ b/lldb-multipython/CMakeLists.txt
@@ -81,6 +81,13 @@ foreach(_py IN LISTS LLDB_PYTHONS)
       # explicitly to match the stage-2 runtimes layout (lib/<triple>/libc++.so.1).
       # Without this the standalone lldb fails: "libc++.so.1: cannot open ...".
       -DLLVM_DEFAULT_TARGET_TRIPLE=${LLVM_DEFAULT_TARGET_TRIPLE}
+      # llvm_setup_rpath (AddLLVM.cmake) appends $ORIGIN/../lib/<triple> to every
+      # tool's install RPATH only when LLVM_ENABLE_PER_TARGET_RUNTIME_DIR is set.
+      # It defaults ON (Linux) inside llvm/CMakeLists.txt, which a standalone
+      # LLDB configure never runs, and LLVMConfig.cmake doesn't export it either
+      # — so without this the lldb binaries get only $ORIGIN/../lib and fail at
+      # runtime with "libc++.so.1: cannot open shared object file".
+      -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
       # Per-Python binding.
       -DLLDB_ENABLE_PYTHON=ON
       -DPython3_EXECUTABLE=${_py}


### PR DESCRIPTION
## Problem

The [master build](https://github.com/karellen/karellen-llvm/actions/runs/30049327432/job/89347672887) failed in `test-build.sh`:

```
lldb: error while loading shared libraries: libc++.so.1: cannot open shared object file: No such file or directory
```

`clang` and the other in-tree tools resolved `libc++.so.1` fine; only the standalone-built `lldb` failed.

## Root cause

`libc++.so.1` is installed in the per-target runtime dir `lib/x86_64-unknown-linux-gnu/`. `llvm_setup_rpath` (`AddLLVM.cmake`) appends `$ORIGIN/../lib/<triple>` to every tool's install RPATH **only when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` is set**. That variable defaults ON (Linux) inside `llvm/CMakeLists.txt`, which a standalone LLDB configure never runs, and `LLVMConfig.cmake` does not export it. So the per-Python `lldb` binaries got only `$ORIGIN/../lib` in their RUNPATH and could not resolve `libc++.so.1` from the installed wheel layout.

The driver already passes `LLVM_DEFAULT_TARGET_TRIPLE` for the same not-exported-by-LLVMConfig reason, but the triple alone is inert — the rpath branch is gated on `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR`.

## Fix

Pass `-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON` in the `lldb-multipython` driver's `CMAKE_ARGS`, matching the in-tree stage-2 behavior. Verified by this PR's CI build (`test-build.sh` runs `lldb --version` against the installed wheels).